### PR TITLE
update graphnode to v0.26.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - ipfs:/data/ipfs
 
   graph:
-    image: graphprotocol/graph-node:v0.25.0
+    image: graphprotocol/graph-node:v0.26.0
     container_name: circles-graph-node
     depends_on:
       - db


### PR DESCRIPTION
upgrade graphnode to v0.26.0 as our hosted service is using.
test with services:
`api:1.4.0`
`core: 2.10.12`
`relayer: v4.1.11`

**test results** 
``` 
PASS  test/token.test.js (401.331 s)
 PASS  test/organization.test.js (163.471 s)
 PASS  test/safe.test.js (146.706 s)
 PASS  test/activity.test.js (96.631 s)
 PASS  test/trust.test.js (92.626 s)
 PASS  test/utils.test.js (34.484 s)
 PASS  test/user.test.js
 PASS  test/common.test.js
 PASS  test/lib.test.js

Test Suites: 9 passed, 9 total
Tests:       56 passed, 56 total
Snapshots:   0 total
```


Closes #42 