### PR TITLE
share volume pathfinder with db container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ./db/init-dbs.sh:/docker-entrypoint-initdb.d/init-dbs.sh
       - data:/var/lib/postgresql/data
+      - pathfinder:/usr/src/app/edges-data
 
   redis:
     image: redis:6.0.1-alpine


### PR DESCRIPTION
- make circles-db container to have access to `usr/src/app/edges-data/` to write `edges.csv` 
- [ ] yet not fixed the issue with permissions, so when executing the command `pg` this can be accessed `UnhandledPromiseRejectionWarning: error: could not open file "/usr/src/app/edges-data/edges.csv" for writing: Permission denied`