### PR TITLE
Fix dependencies errors for subgraph repo

### DIFF
--- a/scripts/deploy-subgraph.sh
+++ b/scripts/deploy-subgraph.sh
@@ -16,7 +16,7 @@ git reset --hard v1.4.0
 
 # Install dependencies
 echo "Installing npm dependencies .."
-npm install &> /dev/null
+npm ci &> /dev/null
 
 # Link to .env file
 ln -s ../../.env .env

--- a/scripts/migrate-contracts.sh
+++ b/scripts/migrate-contracts.sh
@@ -17,7 +17,7 @@ git reset --hard v3.3.1
 
 # Install dependencies
 echo "Installing npm dependencies .."
-npm install &> /dev/null
+npm ci &> /dev/null
 
 # Compile contracts
 ./node_modules/.bin/truffle compile


### PR DESCRIPTION
Closes #73 

- Install dependencies with `npm ci` instead of `npm install`.